### PR TITLE
Add Min / Max tempatures

### DIFF
--- a/app/services/weather_service.rb
+++ b/app/services/weather_service.rb
@@ -38,22 +38,25 @@ class WeatherService
   private
 
   def get_coordinates(city_name)
-    response = self.class.get("http://api.openweathermap.org/geo/1.0/direct", {
-      query: {
-        q: city_name,
-        limit: 1,
-        appid: @api_key
-      }
-    })
+    cache_key = "coordinates_#{city_name.downcase.strip}"
+    Rails.cache.fetch(cache_key, expires_in: 1.week) do
+      response = self.class.get("http://api.openweathermap.org/geo/1.0/direct", {
+        query: {
+          q: city_name,
+          limit: 1,
+          appid: @api_key
+        }
+      })
 
-    if response.success? && response.parsed_response.any?
-      location = response.parsed_response.first
-      {
-        lat: location["lat"],
-        lon: location["lon"]
-      }
-    else
-      nil
+      if response.success? && response.parsed_response.any?
+        location = response.parsed_response.first
+        {
+          lat: location["lat"],
+          lon: location["lon"]
+        }
+      else
+        nil
+      end
     end
   end
 

--- a/app/views/cities/index.html.erb
+++ b/app/views/cities/index.html.erb
@@ -27,7 +27,9 @@
             <thead class="bg-gray-50">
               <tr>
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">City</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Temperature</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Low</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Current</th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">High</th>
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Condition</th>
                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
               </tr>
@@ -41,9 +43,31 @@
                   <td class="px-6 py-4 whitespace-nowrap">
                     <div class="text-sm text-gray-900">
                       <% if weather %>
+                        <span class="font-semibold"><%= weather[:temp_min_c] %>°C</span>
+                        <span class="text-gray-500 mx-2">/</span>
+                        <span class="font-semibold"><%= weather[:temp_min_f] %>°F</span>
+                      <% else %>
+                        <span class="text-gray-500">Weather unavailable</span>
+                      <% end %>
+                    </div>
+                  </td>
+                  <td class="px-6 py-4 whitespace-nowrap">
+                    <div class="text-sm text-gray-900">
+                      <% if weather %>
                         <span class="font-semibold"><%= weather[:temp_c] %>°C</span>
                         <span class="text-gray-500 mx-2">/</span>
                         <span class="font-semibold"><%= weather[:temp_f] %>°F</span>
+                      <% else %>
+                        <span class="text-gray-500">Weather unavailable</span>
+                      <% end %>
+                    </div>
+                  </td>
+                  <td class="px-6 py-4 whitespace-nowrap">
+                    <div class="text-sm text-gray-900">
+                      <% if weather %>
+                        <span class="font-semibold"><%= weather[:temp_max_c] %>°C</span>
+                        <span class="text-gray-500 mx-2">/</span>
+                        <span class="font-semibold"><%= weather[:temp_max_f] %>°F</span>
                       <% else %>
                         <span class="text-gray-500">Weather unavailable</span>
                       <% end %>

--- a/test/controllers/cities_controller_test.rb
+++ b/test/controllers/cities_controller_test.rb
@@ -20,9 +20,9 @@ class CitiesControllerTest < ActionController::TestCase
     def WeatherService.get_weather(city)
       case city
       when "London"
-        { city: "London", temp_c: 15.0, temp_f: 59.0, condition: "Cloudy", icon: "04d" }
+        { city: "London", temp_c: 15.0, temp_f: 59.0, temp_min_c: 12.0, temp_min_f: 53.6, temp_max_c: 18.0, temp_max_f: 64.4, condition: "Cloudy", icon: "04d" }
       when "New York"
-        { city: "New York", temp_c: 20.0, temp_f: 68.0, condition: "Sunny", icon: "01d" }
+        { city: "New York", temp_c: 20.0, temp_f: 68.0, temp_min_c: 17.0, temp_min_f: 62.6, temp_max_c: 23.0, temp_max_f: 73.4, condition: "Sunny", icon: "01d" }
       else
         nil
       end
@@ -32,8 +32,8 @@ class CitiesControllerTest < ActionController::TestCase
     assert_response :success
     assert_equal [ "London", "New York" ], assigns(:cities)
     expected_weather = [
-      { city: "London", temp_c: 15.0, temp_f: 59.0, condition: "Cloudy", icon: "04d" },
-      { city: "New York", temp_c: 20.0, temp_f: 68.0, condition: "Sunny", icon: "01d" }
+      { city: "London", temp_c: 15.0, temp_f: 59.0, temp_min_c: 12.0, temp_min_f: 53.6, temp_max_c: 18.0, temp_max_f: 64.4, condition: "Cloudy", icon: "04d" },
+      { city: "New York", temp_c: 20.0, temp_f: 68.0, temp_min_c: 17.0, temp_min_f: 62.6, temp_max_c: 23.0, temp_max_f: 73.4, condition: "Sunny", icon: "01d" }
     ]
     assert_equal expected_weather, assigns(:weather_data)
   end

--- a/test/services/weather_service_test.rb
+++ b/test/services/weather_service_test.rb
@@ -13,19 +13,32 @@ class WeatherServiceTest < ActiveSupport::TestCase
     assert_equal 212.0, @service.send(:celsius_to_fahrenheit, 100)
   end
 
-  test "parse_weather_response formats data correctly" do
+  test "parse_onecall_response formats data correctly" do
     api_response = {
-      "name" => "New York",
-      "main" => { "temp" => 25.0 },
-      "weather" => [ { "description" => "partly cloudy", "icon" => "02d" } ]
+      "current" => {
+        "temp" => 25.0,
+        "weather" => [ { "description" => "partly cloudy", "icon" => "02d" } ]
+      },
+      "daily" => [
+        {
+          "temp" => {
+            "min" => 22.0,
+            "max" => 28.0
+          }
+        }
+      ]
     }
 
-    result = @service.send(:parse_weather_response, api_response)
+    result = @service.send(:parse_onecall_response, api_response, "New York")
 
     expected = {
       city: "New York",
       temp_c: 25.0,
       temp_f: 77.0,  # 25°C = 77°F
+      temp_min_c: 22.0,
+      temp_min_f: 71.6,  # 22°C = 71.6°F
+      temp_max_c: 28.0,
+      temp_max_f: 82.4,  # 28°C = 82.4°F
       condition: "Partly Cloudy",
       icon: "02d"
     }
@@ -56,22 +69,37 @@ class WeatherServiceTest < ActiveSupport::TestCase
     service = WeatherService.new
     service.instance_variable_set(:@api_key, @valid_api_key)
 
-    # Mock the HTTParty get method
-    mock_response = Struct.new(:success?, :parsed_response).new(
-      true,
-      {
-        "name" => @test_city,
-        "main" => { "temp" => 20.0 },
-        "weather" => [ { "description" => "clear sky", "icon" => "01d" } ]
-      }
-    )
-
-    # Stub the class method
-    WeatherService.define_singleton_method(:get) do |*args|
-      mock_response
+    # Mock the HTTParty get method to handle both geocoding and One Call API
+    WeatherService.define_singleton_method(:get) do |url, options|
+      if url.include?("geo/1.0/direct")
+        # Mock geocoding response
+        Struct.new(:success?, :parsed_response).new(
+          true,
+          [{ "lat" => 51.5074, "lon" => -0.1278 }]
+        )
+      else
+        # Mock One Call API response
+        Struct.new(:success?, :parsed_response).new(
+          true,
+          {
+            "current" => {
+              "temp" => 20.0,
+              "weather" => [ { "description" => "clear sky", "icon" => "01d" } ]
+            },
+            "daily" => [
+              {
+                "temp" => {
+                  "min" => 18.0,
+                  "max" => 22.0
+                }
+              }
+            ]
+          }
+        )
+      end
     end
 
-    # Multiple calls should return the same result
+    # Multiple calls should return the same result (cached)
     result1 = service.send(:fetch_weather_by_city, @test_city)
     result2 = service.send(:fetch_weather_by_city, @test_city)
     result3 = service.send(:fetch_weather_by_city, @test_city)
@@ -79,5 +107,38 @@ class WeatherServiceTest < ActiveSupport::TestCase
     assert_equal @test_city, result1[:city]
     assert_equal result1, result2
     assert_equal result2, result3
+  end
+
+  test "get_coordinates returns lat/lon for valid city" do
+    service = WeatherService.new
+    service.instance_variable_set(:@api_key, @valid_api_key)
+
+    # Mock geocoding API response
+    mock_response = Struct.new(:success?, :parsed_response).new(
+      true,
+      [{ "lat" => 51.5074, "lon" => -0.1278 }]
+    )
+
+    WeatherService.define_singleton_method(:get) do |*args|
+      mock_response
+    end
+
+    result = service.send(:get_coordinates, "London")
+    assert_equal({ lat: 51.5074, lon: -0.1278 }, result)
+  end
+
+  test "get_coordinates returns nil for invalid city" do
+    service = WeatherService.new
+    service.instance_variable_set(:@api_key, @valid_api_key)
+
+    # Mock empty geocoding response
+    mock_response = Struct.new(:success?, :parsed_response).new(true, [])
+
+    WeatherService.define_singleton_method(:get) do |*args|
+      mock_response
+    end
+
+    result = service.send(:get_coordinates, "InvalidCity")
+    assert_nil result
   end
 end

--- a/test/services/weather_service_test.rb
+++ b/test/services/weather_service_test.rb
@@ -75,7 +75,7 @@ class WeatherServiceTest < ActiveSupport::TestCase
         # Mock geocoding response
         Struct.new(:success?, :parsed_response).new(
           true,
-          [{ "lat" => 51.5074, "lon" => -0.1278 }]
+          [ { "lat" => 51.5074, "lon" => -0.1278 } ]
         )
       else
         # Mock One Call API response
@@ -116,7 +116,7 @@ class WeatherServiceTest < ActiveSupport::TestCase
     # Mock geocoding API response
     mock_response = Struct.new(:success?, :parsed_response).new(
       true,
-      [{ "lat" => 51.5074, "lon" => -0.1278 }]
+      [ { "lat" => 51.5074, "lon" => -0.1278 } ]
     )
 
     WeatherService.define_singleton_method(:get) do |*args|


### PR DESCRIPTION
# Add daily low/high temperature display with OpenWeatherMap One Call API

  ## Summary
  • Enhanced weather comparison table to show daily low, current, and high temperatures in both °C and °F
  • Migrated from current weather API to One Call API 3.0 for accurate daily temperature ranges
  • Added geocoding to convert city names to coordinates for One Call API compatibility
  • Implemented coordinate caching (1 week) to reduce API calls and improve performance

  ## Technical Changes
  • **WeatherService**: Switched to two-step API process (geocoding → One Call API) to get actual daily min/max temperatures instead of spatial
  variations
  • **UI**: Updated table to display Low | Current | High | Condition | Actions columns
  • **Caching**: Added separate caching for coordinates (1 week) and weather data (15 minutes)
  • **Tests**: Updated all service and controller tests for new API structure and data format
